### PR TITLE
Update installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Certutil is a cli to help you to easily look inside certificates and debug issue
 I got tired of googling for openssl commands and wanted something simple and easy to use with a memorable cli. 
 
 ## Usage
-Install with `go get`
+Install with `go installt`
 
 ```
-$ go get github.com/jsws/certutil
+$ go install github.com/jsws/certutil@latest
 ```
 
 ### Info

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Certutil is a cli to help you to easily look inside certificates and debug issue
 I got tired of googling for openssl commands and wanted something simple and easy to use with a memorable cli. 
 
 ## Usage
-Install with `go installt`
+Install with `go install`
 
 ```
 $ go install github.com/jsws/certutil@latest


### PR DESCRIPTION
Recent `go` versions whinge if you try to install commands using `go get`